### PR TITLE
SI-8892 Память, утечки памяти

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 }
 
 dependencies {
+    debugImplementation ("com.squareup.leakcanary:leakcanary-android:2.2")
 
     implementation("androidx.core:core-ktx:1.7.0")
     implementation("androidx.appcompat:appcompat:1.4.0")


### PR DESCRIPTION
В ПР добавил только LeakCanary.
В ходе исследования утечек памяти, выяснилось что VmPolicy не очень подходящий инструмент для этого, вот несколько причин почему так:
1) он не показывает где конкретно возникает утечка, а показывает, что она просто есть
![Снимок экрана 2024-04-17 175556](https://github.com/apatia02/fragment_manager/assets/79794866/6033bc83-4ccc-4683-92a9-4f26080441b3)

2) каждое пересоздание активити (смена конфигурации, ребилд), даже если активити пустая, он также считал как утечка памяти, хотя не профилировщик, не канарейка не замечал утечку.
![Снимок экрана 2024-04-18 160242](https://github.com/apatia02/fragment_manager/assets/79794866/16347c1c-665f-45c7-84a7-0f731fbd52b0)

Также вот несколько утечек, которые я смог симулировать:
1) ![Снимок экрана 2024-04-18 165308](https://github.com/apatia02/fragment_manager/assets/79794866/e26437cc-268e-4917-89fc-0c5a81da1871)
![Снимок экрана 2024-04-18 165316](https://github.com/apatia02/fragment_manager/assets/79794866/70d127df-01a7-4539-a780-d3b562900c12)

2) Утечка связанная с потоком: 
![image](https://github.com/apatia02/fragment_manager/assets/79794866/5605c6ef-d7ec-41ca-b632-fc608e7b9d6c)
![Снимок экрана 2024-04-18 165747](https://github.com/apatia02/fragment_manager/assets/79794866/de319b43-0859-4736-a893-a97e9bb1db79)

Несколько способов предотвратить такие утечки:
1) При использовании ссылки на активити или фрагмент использовать `WeakReference`, таким образом сборщик мусора сможет удалить ссылку и утечки не будет.
2) Удалять ссылки на объект, а также отписываться от ресурсов в методах жизненного цикла, например, `onDestroy()`.
3) Использовать `try-finally`, то есть в блоке `try` происходит работа с ресурсами (файлы, бд, потоки), а в блоке `finally` происходит отписка от ресурсов.

Также в ходе исследования выяснилось, что ранее созданный навигатор тоже содержит утечки памяти, в частности сам стек, который хранит фрагменты, хотя они уже уничтожились.

![Снимок экрана 2024-04-18 124033](https://github.com/apatia02/fragment_manager/assets/79794866/84b81a57-829c-4e3a-bcaa-e5b6e3d007c0)

Это утечка решалась, если фрагменты в стеке хранить с помощью слабой ссылки.

![Снимок экрана 2024-04-18 124033](https://github.com/apatia02/fragment_manager/assets/79794866/fab9fbfa-f871-43e5-b065-6b1d7d7a864c)

Но в этом случае возникает другая проблема, фрагменты перестают хранится в стеке, так как они связаны слабой ссылкой.
Как итог я оставил все как есть и добавил канарейку.