### PR TITLE
Si 9574 настройка каналов уведомлений

### DIFF
--- a/app/src/main/java/com/example/fragment_manager/App.kt
+++ b/app/src/main/java/com/example/fragment_manager/App.kt
@@ -1,8 +1,42 @@
 package com.example.fragment_manager
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import com.example.fragment_manager.di.AppComponent
 
 class App : Application() {
     val appComponent = AppComponent()
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannels()
+    }
+
+    private fun createNotificationChannels() {
+        val channelTabFragments = NotificationChannel(
+            CHANNEL_FOR_TAB_FRAGMENTS_ID,
+            getString(R.string.channel_for_tab_fragments),
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = getString(R.string.channel_for_tab_fragments_description)
+        }
+
+        val channelFunnyFragment = NotificationChannel(
+            CHANNEL_FOR_FUNNY_FRAGMENT_ID,
+            getString(R.string.channel_for_funny_fragment),
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = getString(R.string.channel_for_funny_fragment_description)
+        }
+
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channelTabFragments)
+        manager.createNotificationChannel(channelFunnyFragment)
+    }
+
+    companion object {
+        const val CHANNEL_FOR_TAB_FRAGMENTS_ID = "channel_for_tab_fragments_id"
+        const val CHANNEL_FOR_FUNNY_FRAGMENT_ID = "channel_for_funny_fragment_id"
+    }
 }

--- a/app/src/main/java/com/example/fragment_manager/firebase/NotificationHelper.kt
+++ b/app/src/main/java/com/example/fragment_manager/firebase/NotificationHelper.kt
@@ -1,9 +1,9 @@
 package com.example.fragment_manager.firebase
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import androidx.core.app.NotificationCompat
+import com.example.fragment_manager.App
 import com.example.fragment_manager.R
 import com.google.firebase.messaging.RemoteMessage
 
@@ -14,29 +14,24 @@ class NotificationHelper(private val context: Context) {
     }
 
     fun showNotification(remoteMessage: RemoteMessage) {
-        createNotificationChannel()
-        val notificationBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(R.drawable.fun_1)
-            .setContentTitle(remoteMessage.notification?.title)
-            .setContentText(remoteMessage.notification?.body)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setAutoCancel(true)
+        val channel = App.CHANNEL_FOR_TAB_FRAGMENTS_ID
+        if (!checkIsChannelEnable(channel)) {
+            return
+        }
+        val notificationBuilder =
+            NotificationCompat.Builder(context, channel)
+                .setSmallIcon(R.drawable.fun_1)
+                .setContentTitle(remoteMessage.notification?.title)
+                .setContentText(remoteMessage.notification?.body)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true)
 
         val notificationId = System.currentTimeMillis().toInt()
         notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
-    private fun createNotificationChannel() {
-        val name = "Default Channel"
-        val descriptionText = "Default notification channel"
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
-        val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
-            description = descriptionText
-        }
-        notificationManager.createNotificationChannel(channel)
-    }
-
-    companion object {
-        private const val CHANNEL_ID = "default_channel_id"
+    private fun checkIsChannelEnable(channelId: String): Boolean {
+        val channel = notificationManager.getNotificationChannel(channelId)
+        return channel != null && channel.importance != NotificationManager.IMPORTANCE_NONE
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="open_fun_2">Открыть смешнявку 2</string>
     <string name="open_fun_3">Открыть смешнявку 3</string>
     <string name="open_fun_4">Открыть смешнявку 4</string>
+    <string name="channel_for_tab_fragments">channel for tab fragments</string>
+    <string name="channel_for_funny_fragment">channel for funny fragment</string>
+    <string name="channel_for_tab_fragments_description">This is channel for tab fragments</string>
+    <string name="channel_for_funny_fragment_description">This is channel for fragment with funny image</string>
 </resources>


### PR DESCRIPTION
### Что было сделано

Теперь в `App` создаются два канала для уведомлений (уведомления связанные с фрагментами на табах и связанные с фрагментом с картинкой)

### На что стоит обратить внимание

на класс `App`

### Скриншоты и видео работы

<details>
<summary>Настройка каналов приложения</summary>

<img src=https://github.com/apatia02/fragment_manager/assets/79794866/43ab330e-93cc-47e7-a9bb-07c4be25a8bb width="300" />

<!-- Повторите этот блок для каждого скриншота -->

</details>