### PR TITLE
SI-9578 Недоступность уведомлений для скрытия свайпом

### DIFF
--- a/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationExtensions.kt
+++ b/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationExtensions.kt
@@ -7,6 +7,7 @@ import com.example.fragment_manager.presentation.constants.TAB_3_ID
 import com.example.fragment_manager.presentation.constants.TAB_4_ID
 import com.example.fragment_manager.presentation.notification.NotificationTypes.CustomWithReply
 import com.example.fragment_manager.presentation.notification.NotificationTypes.ExpandedWithImg
+import com.example.fragment_manager.presentation.notification.NotificationTypes.NonCancelable
 import com.example.fragment_manager.presentation.notification.NotificationTypes.NotificationsWithNavigations.NavigationToTab
 import com.example.fragment_manager.presentation.notification.NotificationTypes.NotificationsWithNavigations.SingleWithNavigation
 import com.google.firebase.messaging.RemoteMessage.Notification
@@ -22,6 +23,11 @@ fun Notification.mapToNotificationType(): NotificationTypes {
             body = this.body.orEmpty()
         )
 
+        this.title?.contains("cancel") ?: false -> NonCancelable(
+            title = this.title.orEmpty(),
+            body = this.body.orEmpty()
+        )
+
         else -> this.getNavigationToTab()
     }
     return notification.setId(notificationId)
@@ -32,6 +38,7 @@ private fun NotificationTypes.setId(id: Int): NotificationTypes {
         is NavigationToTab -> this.copy(id = id)
         is ExpandedWithImg -> this.copy(id = id)
         is CustomWithReply -> this.copy(id = id)
+        is NonCancelable -> this.copy(id = id)
         else -> this
     }
 }

--- a/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationTypes.kt
+++ b/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationTypes.kt
@@ -39,6 +39,16 @@ sealed class NotificationTypes(
         override val priority: Int = NotificationCompat.PRIORITY_HIGH
     ) : NotificationTypes()
 
+    data class NonCancelable(
+        override val id: Int = DEFAULT_INT,
+        override val channel: String = App.CHANNEL_FOR_TAB_FRAGMENTS_ID,
+        override val title: String = EMPTY_STRING,
+        override val body: String = EMPTY_STRING,
+        override val group: String = NotificationHelper.GROUP_CANCEL,
+        override val groupId: Int = NotificationHelper.GROUP_CANCEL_ID,
+        override val priority: Int = NotificationCompat.PRIORITY_HIGH
+    ) : NotificationTypes()
+
     sealed class NotificationsWithNavigations : NotificationTypes() {
 
         data class NavigationToTab(

--- a/app/src/main/java/com/example/fragment_manager/presentation/notification/ReplyReceiver.kt
+++ b/app/src/main/java/com/example/fragment_manager/presentation/notification/ReplyReceiver.kt
@@ -5,12 +5,14 @@ import android.app.RemoteInput
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.example.fragment_manager.domain.DEFAULT_INT
 import com.example.fragment_manager.presentation.activity.MainActivity
 
 class ReplyReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val replyText = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(KEY_TEXT_REPLY)
-        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, DEFAULT_INT)
+        val groupId = intent.getIntExtra(EXTRA_GROUP_ID, DEFAULT_INT)
         if (replyText != null) {
             val responseIntent = Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -18,15 +20,27 @@ class ReplyReceiver : BroadcastReceiver() {
             }
             context.startActivity(responseIntent)
         }
-        if (notificationId != -1) {
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (notificationId != DEFAULT_INT) {
             notificationManager.cancel(notificationId)
         }
+        if (groupId != DEFAULT_INT && checkIsCancelablePushLast(notificationManager)) {
+            notificationManager.cancel(groupId)
+        }
+    }
+
+    private fun checkIsCancelablePushLast(notificationManager: NotificationManager): Boolean {
+        val activePushes = notificationManager.activeNotifications.toList()
+        val countCancelablePushes =
+            activePushes.count { it.notification.group == NotificationHelper.GROUP_CANCEL }
+        return countCancelablePushes == 1
     }
 
     companion object {
         const val KEY_TEXT_REPLY = "key text reply"
         const val EXTRA_REPLY = "extra reply"
-        const val EXTRA_NOTIFICATION_ID = "extra reply"
+        const val EXTRA_NOTIFICATION_ID = "extra notification id"
+        const val EXTRA_GROUP_ID = "extra group id"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="channel_for_tab_fragments_description">This is channel for tab fragments</string>
     <string name="channel_for_funny_fragment_description">This is channel for fragment with funny image</string>
     <string name="reply_label">Введите id таба, на котором должны быть картинка</string>
+    <string name="cancel">Отмена</string>
 </resources>


### PR DESCRIPTION

### Что было сделано

Был добавлен новый тип уведомления, незакрываемое обычным способом уведомление, у него есть кнопка, по которой уже можно закрыть.

### На что стоит обратить внимание

Первоначально эффект недоступности закрытия планировалось достичь созданием сервиса, но в последствии было решено достичь требуемого эффекта с помощью `.setOngoing(true)` у уведомления.

### Скриншоты и видео работы

<details>
<summary>Недоступное для обычной отмены уведомление</summary>


https://github.com/apatia02/fragment_manager/assets/79794866/9b66374d-d531-4b11-b878-393a8e876a9a


</details>