### PR TITLE
SI-9579 Работа с бейджами и их кастомизация

### DIFF
--- a/app/src/main/java/com/example/fragment_manager/App.kt
+++ b/app/src/main/java/com/example/fragment_manager/App.kt
@@ -20,6 +20,7 @@ class App : Application() {
             NotificationManager.IMPORTANCE_DEFAULT
         ).apply {
             description = getString(R.string.channel_for_tab_fragments_description)
+            setShowBadge(true)
         }
 
         val channelFunnyFragment = NotificationChannel(
@@ -28,6 +29,7 @@ class App : Application() {
             NotificationManager.IMPORTANCE_HIGH
         ).apply {
             description = getString(R.string.channel_for_funny_fragment_description)
+            setShowBadge(false)
         }
 
         val manager = getSystemService(NotificationManager::class.java)

--- a/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationHelper.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.widget.RemoteViews
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.Action
 import androidx.core.app.NotificationCompat.BigPictureStyle
 import androidx.core.app.NotificationCompat.Builder
@@ -106,6 +107,8 @@ class NotificationHelper(private val context: Context) {
             .build()
 
         return Builder(context, channel)
+            .setPriority(priority)
+            .setGroup(group)
             .setSmallIcon(R.drawable.ic_launcher_background)
             .setStyle(DecoratedCustomViewStyle())
             .setCustomContentView(notificationLayout)
@@ -124,17 +127,28 @@ class NotificationHelper(private val context: Context) {
     }
 
     private fun Builder.buildNotificationBuilder(notificationType: NotificationsWithNavigations): Builder {
+        var notification = this
         val intent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
             when (notificationType) {
-                is NavigationToTab -> putExtra(TAB_ARGUMENT, notificationType.tabId)
+                is NavigationToTab -> {
+                    putExtra(TAB_ARGUMENT, notificationType.tabId)
+                    notification =
+                        notification.setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL)
+                }
+
                 is SingleWithNavigation -> putExtra(TAB_ARGUMENT, notificationType.tabId)
             }
         }
         val pendingIntent =
-            PendingIntent.getActivity(context, notificationType.id, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+            PendingIntent.getActivity(
+                context,
+                notificationType.id,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT
+            )
 
-        return this.setContentIntent(pendingIntent)
+        return notification.setContentIntent(pendingIntent)
     }
 
     private fun Builder.buildNotificationBuilder(notificationType: ExpandedWithImg): Builder {
@@ -155,7 +169,12 @@ class NotificationHelper(private val context: Context) {
             putExtra(EXTRA_GROUP_ID, notificationType.groupId)
         }
         val cancelPendingIntent: PendingIntent =
-            PendingIntent.getBroadcast(context, notificationType.id, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            PendingIntent.getBroadcast(
+                context,
+                notificationType.id,
+                cancelIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT
+            )
         return this
             .addAction(
                 googleMaterialR.drawable.mtrl_ic_cancel,

--- a/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationTypes.kt
+++ b/app/src/main/java/com/example/fragment_manager/presentation/notification/NotificationTypes.kt
@@ -68,7 +68,7 @@ sealed class NotificationTypes(
             override val channel: String = App.CHANNEL_FOR_FUNNY_FRAGMENT_ID,
             override val title: String = EMPTY_STRING,
             override val body: String = EMPTY_STRING,
-            override val priority: Int = NotificationCompat.PRIORITY_HIGH
+            override val priority: Int = NotificationCompat.PRIORITY_DEFAULT
         ) : NotificationsWithNavigations()
     }
 }


### PR DESCRIPTION
### Что было сделано

К каналам добавлен параметр показа или не показа бейджов, канал, связанный с табами показывается в бейдже. На уведомление с навигацией на таб, добавлена кастомизация бейджа с помощью `.setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL)`

### На что стоит обратить внимание

На видео, показано какие уведомления поставляются, а потом показывается , что только уведомления на канале с табами показываются на бейдже.

### Скриншоты и видео работы

<details>
<summary>Работа бейджов</summary>

https://github.com/apatia02/fragment_manager/assets/79794866/81027ee9-a1cf-4256-ad4b-6fa8211cd307

</details>